### PR TITLE
Add dry-run params

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ deployment manifest and then deploy.
 
 * `no_redact`: *Optional* Removes redacted from Bosh output. Defaults to false.
 
+* `dry_run`: *Optional* Shows the deployment diff without running a deploy. Defaults to false.
+
 * `target_file`: *Optional.* Path to a file containing a BOSH director address.
   This allows the target to be determined at runtime, e.g. by acquiring a BOSH
   lite instance using the [Pool

--- a/bosh/director.go
+++ b/bosh/director.go
@@ -19,6 +19,7 @@ type DeployParams struct {
 	VarsFiles []string
 	OpsFiles  []string
 	NoRedact  bool
+	DryRun    bool
 	Cleanup   bool
 	VarsStore string
 }
@@ -63,6 +64,7 @@ func (d BoshDirector) Deploy(manifestBytes []byte, deployParams DeployParams) er
 	deployOpts := boshcmd.DeployOpts{
 		Args:     boshcmd.DeployArgs{Manifest: boshcmd.FileBytesArg{Bytes: manifestBytes}},
 		NoRedact: deployParams.NoRedact,
+		DryRun:   deployParams.DryRun,
 		VarFlags: boshcmd.VarFlags{
 			VarKVs:    varKVsFromVars(deployParams.Vars),
 			VarsFiles: boshVarsFiles,

--- a/bosh/director_test.go
+++ b/bosh/director_test.go
@@ -59,8 +59,10 @@ var _ = Describe("BoshDirector", func() {
 			opsFile.Write(opsFileContents)
 
 			noRedact := true
+			dryRun := false
 			err := director.Deploy(sillyBytes, bosh.DeployParams{
 				NoRedact:  noRedact,
+				DryRun:    dryRun,
 				Vars:      vars,
 				VarsFiles: []string{varFile.Name()},
 				OpsFiles:  []string{opsFile.Name()},
@@ -72,6 +74,7 @@ var _ = Describe("BoshDirector", func() {
 			deployOpts := commandRunner.ExecuteArgsForCall(0).(*boshcmd.DeployOpts)
 			Expect(deployOpts.Args.Manifest.Bytes).To(Equal(sillyBytes))
 			Expect(deployOpts.NoRedact).To(Equal(noRedact))
+			Expect(deployOpts.DryRun).To(Equal(dryRun))
 			Expect(deployOpts.VarKVs).To(Equal(varKVs))
 			Expect(len(deployOpts.VarsFiles)).To(Equal(1))
 			Expect(deployOpts.VarsFiles[0].Vars).To(Equal(boshtpl.StaticVariables{
@@ -135,6 +138,22 @@ var _ = Describe("BoshDirector", func() {
 
 				deployOpts := commandRunner.ExecuteArgsForCall(1).(*boshcmd.DeployOpts)
 				Expect(deployOpts.Args.Manifest.Bytes).To(Equal(sillyBytes))
+			})
+		})
+
+		Context("when dryrun is specified", func() {
+			It("use dry-run flags", func() {
+				dryRun := true
+				err := director.Deploy(sillyBytes, bosh.DeployParams{
+					DryRun: dryRun,
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(commandRunner.ExecuteCallCount()).To(Equal(1))
+
+				deployOpts := commandRunner.ExecuteArgsForCall(0).(*boshcmd.DeployOpts)
+				Expect(deployOpts.Args.Manifest.Bytes).To(Equal(sillyBytes))
+				Expect(deployOpts.DryRun).To(Equal(dryRun))
 			})
 		})
 	})

--- a/concourse/out_params.go
+++ b/concourse/out_params.go
@@ -3,6 +3,7 @@ package concourse
 type OutParams struct {
 	Manifest  string                 `json:"manifest"`
 	NoRedact  bool                   `json:"no_redact,omitempty"`
+	DryRun    bool                   `json:"dry_run,omitempty"`
 	Cleanup   bool                   `json:"cleanup,omitempty"`
 	Releases  []string               `json:"releases,omitempty"`
 	Stemcells []string               `json:"stemcells,omitempty"`

--- a/concourse/out_request_test.go
+++ b/concourse/out_request_test.go
@@ -78,6 +78,39 @@ var _ = Describe("NewOutRequest", func() {
 		}))
 	})
 
+	Context("when the dry run flag is true", func() {
+		It("set dryrun to true in OutParams", func() {
+			config := []byte(`{
+				"params": {
+					"manifest": "path/to/manifest.yml",
+					"dry_run": true
+				},
+				"source": {
+					"deployment": "mydeployment",
+					"target": "director.example.com",
+					"client": "foo",
+					"client_secret": "foobar"
+				}
+			}`)
+
+			source, err := concourse.NewOutRequest(config, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(source).To(Equal(concourse.OutRequest{
+				Source: concourse.Source{
+					Deployment:   "mydeployment",
+					Target:       "director.example.com",
+					Client:       "foo",
+					ClientSecret: "foobar",
+				},
+				Params: concourse.OutParams{
+					Manifest: "path/to/manifest.yml",
+					DryRun:   true,
+				},
+			}))
+		})
+	})
+
 	Context("when source_file param is passed", func() {
 		It("overrides source with the values in the source_file", func() {
 			sourceFile, _ := ioutil.TempFile("", "")

--- a/out/out_command.go
+++ b/out/out_command.go
@@ -64,6 +64,7 @@ func (c OutCommand) Run(outRequest concourse.OutRequest) (OutResponse, error) {
 
 	deployParams := bosh.DeployParams{
 		NoRedact:  outRequest.Params.NoRedact,
+		DryRun:    outRequest.Params.DryRun,
 		Cleanup:   outRequest.Params.Cleanup,
 		Vars:      outRequest.Params.Vars,
 		VarsFiles: varsFilePaths,

--- a/out/out_command_test.go
+++ b/out/out_command_test.go
@@ -81,6 +81,27 @@ var _ = Describe("OutCommand", func() {
 			}))
 		})
 
+		It("dryrun deploys", func() {
+
+			outRequest.Params.DryRun = true
+
+			_, err := outCommand.Run(outRequest)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(director.DeployCallCount()).To(Equal(1))
+			actualManifestYaml, actualDeployParams := director.DeployArgsForCall(0)
+			Expect(actualManifestYaml).To(MatchYAML(manifestYaml))
+			Expect(actualDeployParams).To(Equal(bosh.DeployParams{
+				NoRedact:  true,
+				DryRun:    true,
+				VarsFiles: []string{},
+				OpsFiles:  []string{},
+				Vars: map[string]interface{}{
+					"foo": "bar",
+				},
+			}))
+		})
+
 		It("returns the new version", func() {
 			sillyBytes := []byte{0xFE, 0xED, 0xDE, 0xAD, 0xBE, 0xEF}
 			director.DownloadManifestReturns(sillyBytes, nil)


### PR DESCRIPTION
Hi:

We'd like to add a dry-run param to the resource. This will let Cloudops determine if we are deploying the right things to prod before actually running the deployment.


* It shows the deployment diff without running a deploy.

[#146941389] Go Bosh Deployment Resource can trigger dry-run instead of deploy

Signed-off-by: Renee Chu <rchu@pivotal.io>