### PR TITLE
Add delete param to allow delete deployment before running bosh deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ deployment manifest and then deploy.
 * `cleanup`: *Optional* An boolean that specifies if a bosh cleanup should be
   run after deployment. Defaults to false.
 
+* `delete`: *Optional* An boolean that specifies if delete-deployment should be run before deployment. Defaults 
+  to false.
+
 * `no_redact`: *Optional* Removes redacted from Bosh output. Defaults to false.
 
 * `dry_run`: *Optional* Shows the deployment diff without running a deploy. Defaults to false.

--- a/bosh/director.go
+++ b/bosh/director.go
@@ -22,6 +22,7 @@ type DeployParams struct {
 	NoRedact  bool
 	DryRun    bool
 	Cleanup   bool
+	Delete    bool
 	VarsStore string
 }
 
@@ -85,6 +86,10 @@ func (d BoshDirector) Deploy(manifestBytes []byte, deployParams DeployParams) er
 		varsFSStore.FS = boshFileSystem()
 		varsFSStore.UnmarshalFlag(deployParams.VarsStore)
 		deployOpts.VarsFSStore = varsFSStore
+	}
+
+	if deployParams.Delete {
+		d.commandRunner.Execute(&boshcmd.DeleteDeploymentOpts{})
 	}
 
 	err = d.commandRunner.Execute(&deployOpts)

--- a/bosh/director_test.go
+++ b/bosh/director_test.go
@@ -127,6 +127,22 @@ var _ = Describe("BoshDirector", func() {
 			})
 		})
 
+		Context("when delete is specified", func() {
+			It("deletes a deployment if exists before the deploy", func() {
+
+				err := director.Deploy(sillyBytes, bosh.DeployParams{Delete: true})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(commandRunner.ExecuteCallCount()).To(Equal(2))
+
+				deleteDeploymentOpts := commandRunner.ExecuteArgsForCall(0).(*boshcmd.DeleteDeploymentOpts)
+				Expect(deleteDeploymentOpts.Force).To(Equal(false))
+
+				deployOpts := commandRunner.ExecuteArgsForCall(1).(*boshcmd.DeployOpts)
+				Expect(deployOpts.Args.Manifest.Bytes).To(Equal(sillyBytes))
+			})
+		})
+
 		Context("when cleanup is specified", func() {
 			It("runs a cleanup after the deploy", func() {
 				err := director.Deploy(sillyBytes, bosh.DeployParams{Cleanup: true})

--- a/concourse/out_params.go
+++ b/concourse/out_params.go
@@ -5,6 +5,7 @@ type OutParams struct {
 	NoRedact  bool                   `json:"no_redact,omitempty"`
 	DryRun    bool                   `json:"dry_run,omitempty"`
 	Cleanup   bool                   `json:"cleanup,omitempty"`
+	Delete    bool                   `json:"delete,omitempty"`
 	Releases  []string               `json:"releases,omitempty"`
 	Stemcells []string               `json:"stemcells,omitempty"`
 	Vars      map[string]interface{} `json:"vars,omitempty"`

--- a/out/out_command.go
+++ b/out/out_command.go
@@ -77,6 +77,7 @@ func (c OutCommand) Run(outRequest concourse.OutRequest) (OutResponse, error) {
 		NoRedact: outRequest.Params.NoRedact,
 		DryRun:   outRequest.Params.DryRun,
 		Cleanup:  outRequest.Params.Cleanup,
+		Delete:   outRequest.Params.Delete,
 	}
 
 	var varsStoreFile *os.File


### PR DESCRIPTION
Hi, in one of our use case we want to delete the deployment before bosh deploy because we want the deploy to begin with a fresh state. Refer to #18.