### PR TITLE
Optionally recreate VMs during deploy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ deployment manifest and then deploy.
 
 * `dry_run`: *Optional* Shows the deployment diff without running a deploy. Defaults to false.
 
+* `recreate`: *Optional* Recreate all VMs in deployment. Defaults to false.
+
 * `target_file`: *Optional.* Path to a file containing a BOSH director address.
   This allows the target to be determined at runtime, e.g. by acquiring a BOSH
   lite instance using the [Pool

--- a/bosh/director.go
+++ b/bosh/director.go
@@ -21,6 +21,7 @@ type DeployParams struct {
 	OpsFiles  []string
 	NoRedact  bool
 	DryRun    bool
+	Recreate  bool
 	Cleanup   bool
 	VarsStore string
 }
@@ -76,6 +77,7 @@ func (d BoshDirector) Deploy(manifestBytes []byte, deployParams DeployParams) er
 		Args:     boshcmd.DeployArgs{Manifest: boshcmd.FileBytesArg{Bytes: manifestBytes}},
 		NoRedact: deployParams.NoRedact,
 		DryRun:   deployParams.DryRun,
+		Recreate: deployParams.Recreate,
 		VarFlags: boshcmd.VarFlags{
 			VarKVs:    varKVsFromVars(deployParams.Vars),
 			VarsFiles: boshVarsFiles,

--- a/concourse/out_params.go
+++ b/concourse/out_params.go
@@ -4,6 +4,7 @@ type OutParams struct {
 	Manifest  string                 `json:"manifest"`
 	NoRedact  bool                   `json:"no_redact,omitempty"`
 	DryRun    bool                   `json:"dry_run,omitempty"`
+	Recreate  bool                   `json:"recreate,omitempty"`
 	Cleanup   bool                   `json:"cleanup,omitempty"`
 	Releases  []string               `json:"releases,omitempty"`
 	Stemcells []string               `json:"stemcells,omitempty"`

--- a/out/out_command.go
+++ b/out/out_command.go
@@ -84,6 +84,7 @@ func (c OutCommand) deploy(outRequest concourse.OutRequest) (OutResponse, error)
 	deployParams := bosh.DeployParams{
 		NoRedact: outRequest.Params.NoRedact,
 		DryRun:   outRequest.Params.DryRun,
+		Recreate: outRequest.Params.Recreate,
 		Cleanup:  outRequest.Params.Cleanup,
 	}
 

--- a/out/out_command_test.go
+++ b/out/out_command_test.go
@@ -89,7 +89,31 @@ var _ = Describe("OutCommand", func() {
 		})
 
 		It("dryrun deploys", func() {
+			outRequest.Params.Recreate = true
 
+			_, err := outCommand.Run(outRequest)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, actualInterpolateParams := director.InterpolateArgsForCall(0)
+			Expect(actualInterpolateParams.Vars).To(Equal(
+				map[string]interface{}{
+					"foo": "bar",
+				},
+			))
+
+			Expect(director.DeployCallCount()).To(Equal(1))
+			actualManifestYaml, actualDeployParams := director.DeployArgsForCall(0)
+			Expect(actualManifestYaml).To(MatchYAML(manifestYaml))
+			Expect(actualDeployParams).To(Equal(bosh.DeployParams{
+				NoRedact:  true,
+				Recreate:  true,
+				VarsFiles: nil,
+				OpsFiles:  nil,
+				Vars:      nil,
+			}))
+		})
+
+		It("recreate deploys", func() {
 			outRequest.Params.DryRun = true
 
 			_, err := outCommand.Run(outRequest)


### PR DESCRIPTION
Useful for deployments that require recreating VMs for whatever reason--for example, https://github.com/cloudfoundry/cf-deployment/releases/tag/v1.9.0 recommends recreating VMs.