### PR TITLE
Add skip drain flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ deployment manifest and then deploy.
 
 * `recreate`: *Optional* Recreate all VMs in deployment. Defaults to false.
 
+* `skip_drain`: *Optional* A list of `SkipDrain` strings. Defaults to empty.
+
 * `source_file`: *Optional.* Path to a file containing a BOSH director address.
   This allows the target to be determined at runtime, e.g. by acquiring a BOSH
   lite instance using the [Pool

--- a/bosh/director_test.go
+++ b/bosh/director_test.go
@@ -163,6 +163,25 @@ var _ = Describe("BoshDirector", func() {
 				Expect(deployOpts.DryRun).To(Equal(dryRun))
 			})
 		})
+
+		Context("when skipdrain is specified", func() {
+			It("uses skip-drain flag", func() {
+				err := director.Deploy(sillyBytes, bosh.DeployParams{
+					SkipDrain: []string{"*"},
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(commandRunner.ExecuteCallCount()).To(Equal(1))
+
+				skipDrain := []boshdir.SkipDrain{
+					{All: true},
+				}
+
+				deployOpts := commandRunner.ExecuteArgsForCall(0).(*boshcmd.DeployOpts)
+				Expect(deployOpts.Args.Manifest.Bytes).To(Equal(sillyBytes))
+				Expect(deployOpts.SkipDrain).To(Equal(skipDrain))
+			})
+		})
 	})
 	Describe("Delete", func() {
 		It("tells BOSH to delete the configured deployment", func() {

--- a/concourse/concourse_suite_test.go
+++ b/concourse/concourse_suite_test.go
@@ -4,8 +4,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"testing"
 	"strings"
+	"testing"
 )
 
 func TestOut(t *testing.T) {

--- a/concourse/out_params.go
+++ b/concourse/out_params.go
@@ -5,6 +5,7 @@ type OutParams struct {
 	NoRedact  bool                   `json:"no_redact,omitempty"`
 	DryRun    bool                   `json:"dry_run,omitempty"`
 	Recreate  bool                   `json:"recreate,omitempty"`
+	SkipDrain []string               `json:"skip_drain,omitempty"`
 	Cleanup   bool                   `json:"cleanup,omitempty"`
 	Releases  []string               `json:"releases,omitempty"`
 	Stemcells []string               `json:"stemcells,omitempty"`

--- a/out/out_command.go
+++ b/out/out_command.go
@@ -86,10 +86,11 @@ func (c OutCommand) deploy(outRequest concourse.OutRequest) (OutResponse, error)
 	}
 
 	deployParams := bosh.DeployParams{
-		NoRedact: outRequest.Params.NoRedact,
-		DryRun:   outRequest.Params.DryRun,
-		Recreate: outRequest.Params.Recreate,
-		Cleanup:  outRequest.Params.Cleanup,
+		NoRedact:  outRequest.Params.NoRedact,
+		DryRun:    outRequest.Params.DryRun,
+		Recreate:  outRequest.Params.Recreate,
+		SkipDrain: outRequest.Params.SkipDrain,
+		Cleanup:   outRequest.Params.Cleanup,
 	}
 
 	var varsStoreFile *os.File

--- a/out/out_command_test.go
+++ b/out/out_command_test.go
@@ -138,6 +138,31 @@ var _ = Describe("OutCommand", func() {
 			}))
 		})
 
+		It("deploys with skip drain", func() {
+			outRequest.Params.SkipDrain = []string{"all"}
+
+			_, err := outCommand.Run(outRequest)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, actualInterpolateParams := director.InterpolateArgsForCall(0)
+			Expect(actualInterpolateParams.Vars).To(Equal(
+				map[string]interface{}{
+					"foo": "bar",
+				},
+			))
+
+			Expect(director.DeployCallCount()).To(Equal(1))
+			actualManifestYaml, actualDeployParams := director.DeployArgsForCall(0)
+			Expect(actualManifestYaml).To(MatchYAML(manifestYaml))
+			Expect(actualDeployParams).To(Equal(bosh.DeployParams{
+				NoRedact:  true,
+				SkipDrain: []string{"all"},
+				VarsFiles: nil,
+				OpsFiles:  nil,
+				Vars:      nil,
+			}))
+		})
+
 		It("returns the new version", func() {
 			sillyBytes := []byte{0xFE, 0xED, 0xDE, 0xAD, 0xBE, 0xEF}
 			director.DownloadManifestReturns(sillyBytes, nil)


### PR DESCRIPTION
Sometimes it's useful to deploy without draining some or all instance groups--for example, after you break a drain script 😇

cc @wjwoodson @timothy-spencer