### PR TITLE
Add note about releases overriding manifest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ deployment manifest and then deploy.
   stemcell versions.
 
 * `releases`: *Optional.* An array of globs that should point to where the
-  releases used in the deployment can be found.
+  releases used in the deployment can be found. Release entries in the 
+  manifest with version 'latest' will be updated to the actual provided 
+  release versions.
 
 * `vars`: *Optional.* A collection of variables to be set in the deployment manifest.
 


### PR DESCRIPTION
We were pleasantly surprised to see that the releases we uploaded through this resource magically were overriding the `version: latest`s we have in our manifest. We dug through the code to make sure we knew where this was happening, figured it'd be nice for future users if it was called out in the README.