### PR TITLE
enable to use max in flight option

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,16 +154,18 @@ deployment manifest and then deploy.
 
 * `ops_files`: *Optional.* A collection of ops files to be applied over the deployment manifest.
 
-* `cleanup`: *Optional* An boolean that specifies if a bosh cleanup should be
+* `cleanup`: *Optional.* An boolean that specifies if a bosh cleanup should be
   run after deployment. Defaults to false.
 
-* `no_redact`: *Optional* Removes redacted from Bosh output. Defaults to false.
+* `no_redact`: *Optional.* Removes redacted from Bosh output. Defaults to false.
 
-* `dry_run`: *Optional* Shows the deployment diff without running a deploy. Defaults to false.
+* `dry_run`: *Optional.* Shows the deployment diff without running a deploy. Defaults to false.
 
-* `recreate`: *Optional* Recreate all VMs in deployment. Defaults to false.
+* `max_in_flight`: *Optional.* A number of max in flight option.
 
-* `skip_drain`: *Optional* A collection of instance group names to skip running drain scripts for. Defaults to empty.
+* `recreate`: *Optional.* Recreate all VMs in deployment. Defaults to false.
+
+* `skip_drain`: *Optional.* A collection of instance group names to skip running drain scripts for. Defaults to empty.
 
 * `source_file`: *Optional.* Path to a file containing a BOSH director address.
   This allows the target to be determined at runtime, e.g. by acquiring a BOSH
@@ -173,9 +175,9 @@ deployment manifest and then deploy.
   If both `source_file` and `target` are specified, `source_file` takes
   precedence.
 
-* `delete.enabled`: *Optional* Deletes the configured deployment instead of doing a deploy.
+* `delete.enabled`: *Optional.* Deletes the configured deployment instead of doing a deploy.
 
-* `delete.force`: *Optional* Defaults to `false`. Asks bosh to ignore errors when deleting the configured deployment.
+* `delete.force`: *Optional.* Defaults to `false`. Asks bosh to ignore errors when deleting the configured deployment.
 
 
 ``` yaml

--- a/bosh/director.go
+++ b/bosh/director.go
@@ -101,7 +101,7 @@ func (d BoshDirector) Deploy(manifestBytes []byte, deployParams DeployParams) er
 		Args:        boshcmd.DeployArgs{Manifest: boshcmd.FileBytesArg{Bytes: manifestBytes}},
 		NoRedact:    deployParams.NoRedact,
 		DryRun:      deployParams.DryRun,
-		MaxInFlight: strconv.Itoa(deployParams.MaxInFlight),
+		MaxInFlight: convertMaxInFlight(deployParams.MaxInFlight),
 		Recreate:    deployParams.Recreate,
 		SkipDrain:   skipDrains,
 		VarFlags: boshcmd.VarFlags{
@@ -385,6 +385,13 @@ func parsedSkipDrains(drains []string) ([]boshdir.SkipDrain, error) {
 		parsedDrains[idx] = parsedDrain
 	}
 	return parsedDrains, nil
+}
+
+func convertMaxInFlight(maxInFlight int) string {
+	if maxInFlight == 0 {
+		return ""
+	}
+	return strconv.Itoa(maxInFlight)
 }
 
 func boshFileSystem() boshsys.FileSystem {

--- a/bosh/director.go
+++ b/bosh/director.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"strconv"
 	"time"
 
 	"github.com/cloudfoundry/bosh-deployment-resource/concourse"
@@ -18,16 +19,17 @@ import (
 )
 
 type DeployParams struct {
-	Vars      map[string]interface{}
-	VarFiles  map[string]string
-	VarsFiles []string
-	OpsFiles  []string
-	NoRedact  bool
-	DryRun    bool
-	Recreate  bool
-	SkipDrain []string
-	Cleanup   bool
-	VarsStore string
+	Vars        map[string]interface{}
+	VarFiles    map[string]string
+	VarsFiles   []string
+	OpsFiles    []string
+	NoRedact    bool
+	DryRun      bool
+	MaxInFlight int
+	Recreate    bool
+	SkipDrain   []string
+	Cleanup     bool
+	VarsStore   string
 }
 
 type InterpolateParams struct {
@@ -96,11 +98,12 @@ func (d BoshDirector) Deploy(manifestBytes []byte, deployParams DeployParams) er
 	}
 
 	deployOpts := boshcmd.DeployOpts{
-		Args:      boshcmd.DeployArgs{Manifest: boshcmd.FileBytesArg{Bytes: manifestBytes}},
-		NoRedact:  deployParams.NoRedact,
-		DryRun:    deployParams.DryRun,
-		Recreate:  deployParams.Recreate,
-		SkipDrain: skipDrains,
+		Args:        boshcmd.DeployArgs{Manifest: boshcmd.FileBytesArg{Bytes: manifestBytes}},
+		NoRedact:    deployParams.NoRedact,
+		DryRun:      deployParams.DryRun,
+		MaxInFlight: strconv.Itoa(deployParams.MaxInFlight),
+		Recreate:    deployParams.Recreate,
+		SkipDrain:   skipDrains,
 		VarFlags: boshcmd.VarFlags{
 			VarKVs:    varKVsFromVars(deployParams.Vars),
 			VarsFiles: boshVarsFiles,

--- a/concourse/out_params.go
+++ b/concourse/out_params.go
@@ -1,19 +1,20 @@
 package concourse
 
 type OutParams struct {
-	Manifest  string                 `json:"manifest"`
-	NoRedact  bool                   `json:"no_redact,omitempty"`
-	DryRun    bool                   `json:"dry_run,omitempty"`
-	Recreate  bool                   `json:"recreate,omitempty"`
-	SkipDrain []string               `json:"skip_drain,omitempty"`
-	Cleanup   bool                   `json:"cleanup,omitempty"`
-	Releases  []string               `json:"releases,omitempty"`
-	Stemcells []string               `json:"stemcells,omitempty"`
-	Vars      map[string]interface{} `json:"vars,omitempty"`
-	VarsFiles []string               `json:"vars_files,omitempty"`
-	VarFiles  map[string]string      `json:"var_files,omitempty"`
-	OpsFiles  []string               `json:"ops_files,omitempty"`
-	Delete    DeleteParams           `json:"delete,omitempty"`
+	Manifest    string                 `json:"manifest"`
+	NoRedact    bool                   `json:"no_redact,omitempty"`
+	DryRun      bool                   `json:"dry_run,omitempty"`
+	MaxInFlight int                    `json:"max_in_flight,omitempty"`
+	Recreate    bool                   `json:"recreate,omitempty"`
+	SkipDrain   []string               `json:"skip_drain,omitempty"`
+	Cleanup     bool                   `json:"cleanup,omitempty"`
+	Releases    []string               `json:"releases,omitempty"`
+	Stemcells   []string               `json:"stemcells,omitempty"`
+	Vars        map[string]interface{} `json:"vars,omitempty"`
+	VarsFiles   []string               `json:"vars_files,omitempty"`
+	VarFiles    map[string]string      `json:"var_files,omitempty"`
+	OpsFiles    []string               `json:"ops_files,omitempty"`
+	Delete      DeleteParams           `json:"delete,omitempty"`
 }
 
 type DeleteParams struct {

--- a/out/out_command.go
+++ b/out/out_command.go
@@ -87,12 +87,13 @@ func (c OutCommand) deploy(outRequest concourse.OutRequest) (OutResponse, error)
 	}
 
 	deployParams := bosh.DeployParams{
-		NoRedact:  outRequest.Params.NoRedact,
-		DryRun:    outRequest.Params.DryRun,
-		Recreate:  outRequest.Params.Recreate,
-		SkipDrain: outRequest.Params.SkipDrain,
-		Cleanup:   outRequest.Params.Cleanup,
-		VarFiles:  c.prependResourcesDir(outRequest.Params.VarFiles),
+		NoRedact:    outRequest.Params.NoRedact,
+		DryRun:      outRequest.Params.DryRun,
+		MaxInFlight: outRequest.Params.MaxInFlight,
+		Recreate:    outRequest.Params.Recreate,
+		SkipDrain:   outRequest.Params.SkipDrain,
+		Cleanup:     outRequest.Params.Cleanup,
+		VarFiles:    c.prependResourcesDir(outRequest.Params.VarFiles),
 	}
 
 	var varsStoreFile *os.File

--- a/out/out_command_test.go
+++ b/out/out_command_test.go
@@ -136,6 +136,29 @@ var _ = Describe("OutCommand", func() {
 			}))
 		})
 
+		It("deploys with max in flight", func() {
+			outRequest.Params.MaxInFlight = 5
+
+			_, err := outCommand.Run(outRequest)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, actualInterpolateParams := director.InterpolateArgsForCall(0)
+			Expect(actualInterpolateParams.Vars).To(Equal(
+				map[string]interface{}{
+					"foo": "bar",
+				},
+			))
+
+			Expect(director.DeployCallCount()).To(Equal(1))
+			actualManifestYaml, actualDeployParams := director.DeployArgsForCall(0)
+			Expect(actualManifestYaml).To(MatchYAML(manifestYaml))
+			Expect(actualDeployParams).To(Equal(bosh.DeployParams{
+				NoRedact:    true,
+				MaxInFlight: 5,
+				VarFiles:    map[string]string{},
+			}))
+		})
+
 		It("deploys with skip drain", func() {
 			outRequest.Params.SkipDrain = []string{"all"}
 


### PR DESCRIPTION
I enable to use `--max-in-flight` option.

<details>
<summary>test result</summary>

```
$ ginkgo -r -v                                           
Running Suite: Bosh Suite
=========================
Random Seed: 1554224154
Will run 52 of 52 specs

Stemcell NewStemcells
  parses the stemcell tar
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/stemcell_test.go:11
•
------------------------------
Stemcell NewStemcells when the tgz is not a stemcell
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/stemcell_test.go:26
•
------------------------------
Stemcell NewStemcells when the stemcell is malformed
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/stemcell_test.go:35
•
------------------------------
Stemcell NewStemcells when a stemcell glob is bad
  gives a useful error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/stemcell_test.go:44
•
------------------------------
BoshDirector Deploy
  tells BOSH to deploy the given manifest and parameters
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:47
•
------------------------------
BoshDirector Deploy VarsStore when one is provided
  is used
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:116
•
------------------------------
BoshDirector Deploy VarsStore when one is not provided
  is not used
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:129
•
------------------------------
BoshDirector Deploy when deploying fails
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:140
•
------------------------------
BoshDirector Deploy when cleanup is specified
  runs a cleanup after the deploy
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:150
•
------------------------------
BoshDirector Deploy when dryrun is specified
  use dry-run flags
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:165
•
------------------------------
BoshDirector Deploy when max in flight is specified
  use max-in-flight flags
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:181
•
------------------------------
BoshDirector Deploy when skipdrain is specified
  uses skip-drain flag
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:197
•
------------------------------
BoshDirector Delete
  tells BOSH to delete the configured deployment
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:216
•
------------------------------
BoshDirector Delete when delete fails
  returns the error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:231
•
------------------------------
BoshDirector Interpolate
  tells interpolates a BOSH manifest
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:250
•
------------------------------
BoshDirector Interpolate when interpolating fails
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:302
•
------------------------------
BoshDirector DownloadManifest
  gets the deployment manifest
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:313
•
------------------------------
BoshDirector DownloadManifest when getting the deployment fails
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:326
•
------------------------------
BoshDirector DownloadManifest when getting the manifest fails
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:336
•
------------------------------
BoshDirector UploadRelease
  uploads the given release
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:348
•
------------------------------
BoshDirector UploadRelease when uploading the release fails
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:359
•
------------------------------
BoshDirector ExportReleases
  downloads the given releases
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:412
•
------------------------------
BoshDirector ExportReleases when requesting a release not in the manifest
  errors before downloading any releases
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:454
•
------------------------------
BoshDirector ExportReleases when there is more than one stemcell in the manifest
  errors before downloading any releases
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:467
•
------------------------------
BoshDirector ExportReleases when getting the deployment fails
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:480
•
------------------------------
BoshDirector ExportReleases when exporting releases fails
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:491
•
------------------------------
BoshDirector ExportReleases when getting releases fails
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:502
•
------------------------------
BoshDirector ExportReleases when getting stemcells fails from the deployment
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:514
•
------------------------------
BoshDirector ExportReleases when getting stemcells fails from the director
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:525
•
------------------------------
BoshDirector UploadStemcell
  uploads the given stemcell
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:539
•
------------------------------
BoshDirector UploadStemcell when uploading the stemcell fails
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:550
•
------------------------------
BoshDirector WaitForDeployLock
  waits for the lock to be released
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:561
•
------------------------------
BoshDirector WaitForDeployLock when there are locks
  waits for the lock to be released
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:586
•
------------------------------
BoshDirector WaitForDeployLock when checking the lock fails
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:601
•
------------------------------
Release NewRelease
  parses the release tar
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/release_test.go:11
•
------------------------------
Release NewRelease when the tgz is not a release
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/release_test.go:25
•
------------------------------
Release NewRelease when the release is malformed
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/release_test.go:34
•
------------------------------
Release NewRelease when a release glob is bad
  gives a useful error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/release_test.go:43
•
------------------------------
DeploymentManifest NewDeploymentManifest
  returns an error if parsing invalid yaml
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:12
•
------------------------------
DeploymentManifest UseRelease
  updates the requested release version to match the provided release
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:20
•
------------------------------
DeploymentManifest UseRelease when the release is not found
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:37
•
------------------------------
DeploymentManifest UseRelease when there is no releases section
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:51
•
------------------------------
DeploymentManifest UseStemcell
  updates the requested stemcell version to match the provided stemcell
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:65
•
------------------------------
DeploymentManifest UseStemcell
  does not update stemcells when the version is not latest
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:88
•
------------------------------
DeploymentManifest UseStemcell when the stemcell is not found
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:106
•
------------------------------
DeploymentManifest UseStemcell when the stemcell is not found when there is no stemcells section
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:119
•
------------------------------
DeploymentManifest UseStemcell when more than one stemcell matches
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:133
•
------------------------------
CLI coordinator StartProxy
  starts a proxy server and returns the proxy address
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/cli_coordinator_test.go:29
•
------------------------------
CLI coordinator StartProxy when the proxy is already running
  returns the address for the existing proxy server
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/cli_coordinator_test.go:50
•
------------------------------
CLI coordinator StartProxy when the jumpbox url and the jumpbox ssh key are not set
  does not start a proxy
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/cli_coordinator_test.go:67
•
------------------------------
CLI coordinator StartProxy when the jumpbox url is set and the ssh key is missing
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/cli_coordinator_test.go:83
•
------------------------------
CLI coordinator StartProxy when the jumpbox ssh key is set and the jumpbox url is missing
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/cli_coordinator_test.go:95
•
Ran 52 of 52 Specs in 3.276 seconds
SUCCESS! -- 52 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: Check Suite
==========================
Random Seed: 1554224154
Will run 3 of 3 specs

CheckCommand Run When the manifest SHA does not match with the version provided
  returns the SHA1 of the manifest
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/check/check_command_test.go:43
•
------------------------------
CheckCommand Run When the manifest SHA matches the version provided to the check
  retuns an empty versions array
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/check/check_command_test.go:70
•
------------------------------
CheckCommand Run When the there is an error downloading the manifest
  returns the error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/check/check_command_test.go:84
•
Ran 3 of 3 Specs in 0.001 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: Check Suite
==========================
Random Seed: 1554224154
Will run 0 of 0 specs


Ran 0 of 0 Specs in 0.000 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: In Suite
=======================
Random Seed: 1554224154
Will run 0 of 0 specs


Ran 0 of 0 Specs in 0.000 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: Out Suite
========================
Random Seed: 1554224154
Will run 0 of 0 specs


Ran 0 of 0 Specs in 0.000 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: Concourse Suite
==============================
Random Seed: 1554224154
Will run 13 of 13 specs

NewDynamicSource
  converts the config into a Source
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/source_test.go:14
•
------------------------------
NewDynamicSource when source_file param is passed
  overrides source with the values in the source_file
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/source_test.go:79
•
------------------------------
NewDynamicSource when source_file param is passed when the source_file cannot be read
  errors
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/source_test.go:111
•
------------------------------
NewDynamicSource when decoding fails
  errors
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/source_test.go:121
•
------------------------------
NewDynamicSource when a required parameter is missing
  returns an error with each missing parameter
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/source_test.go:130
•
------------------------------
InRequest NewInRequest when the target is empty
  It sets a placeholder so newing up the director does not fail validation
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/in_request_test.go:12
•
------------------------------
Version
  presents the SHA1 as a string
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/version_test.go:14
•
------------------------------
NewOutRequest
  converts the config into an OutRequest
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/out_request_test.go:14
•
------------------------------
NewOutRequest when the dry run flag is true
  set dryrun to true in OutParams
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/out_request_test.go:90
•
------------------------------
NewOutRequest when source_file param is passed
  overrides source with the values in the source_file
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/out_request_test.go:123
•
------------------------------
NewOutRequest when decoding fails
  errors
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/out_request_test.go:188
•
------------------------------
NewOutRequest when delete is specified
  does not require the manifest parameter
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/out_request_test.go:197
•
------------------------------
NewOutRequest when a required parameter is missing
  returns an error with each missing parameter
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/out_request_test.go:218
•
Ran 13 of 13 Specs in 0.120 seconds
SUCCESS! -- 13 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: In Suite
=======================
Random Seed: 1554224154
Will run 8 of 8 specs

InCommand Run
  writes the manifest and target to disk and returns the version as a response
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:55
•
------------------------------
InCommand Run when the manifest download fails
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:81
•
------------------------------
InCommand Run when the manifest download fails if the error is a 404
  assumes the deployment cannot be found because of an implicit get after a put, where the put was a delete
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:92
•
------------------------------
InCommand Run when downloaded manifest does not match the requested version
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:105
•
------------------------------
InCommand Run when director target does not match the requested version
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:117
•
------------------------------
InCommand Run when requesting compiled_releases
  downloads each release with the version specified in the manifest
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:149
•
------------------------------
InCommand Run when requesting compiled_releases when exporting releases fails
  errors
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:167
•
------------------------------
InCommand Run when there are no releases to compile
  does not export releases
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:180
•
Ran 8 of 8 Specs in 0.300 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: Out Suite
========================
Random Seed: 1554224154
Will run 23 of 23 specs

OutCommand Run
  deploys
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:72
•
------------------------------
OutCommand Run
  deploys with recreate
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:93
•
------------------------------
OutCommand Run
  dryrun deploys
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:116
•
------------------------------
OutCommand Run
  deploys with max in flight
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:139
•
------------------------------
OutCommand Run
  deploys with skip drain
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:162
•
------------------------------
OutCommand Run
  returns the new version
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:185
•
------------------------------
OutCommand Run
  waits for locks on the deployment
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:201
•
------------------------------
OutCommand Run when varsFiles are provided
  interpolates the varsFiles into the manifest but does not delpoy with them
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:234
•
------------------------------
OutCommand Run when varsFiles are provided when a varsFile glob is bad
  gives a useful error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:250
•
------------------------------
OutCommand Run when varFiles are provided
  prepends the paths with the resources directory and passes them to deploy params
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:261
•
------------------------------
OutCommand Run when opsFiles are provided
  interpolates the opsfiles into the manifest but does not delpoy with them
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:302
•
------------------------------
OutCommand Run when opsFiles are provided when a opsFile glob is bad
  gives a useful error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:318
•
------------------------------
OutCommand Run when releases are provided
  uploads all of the releases
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:359
•
------------------------------
OutCommand Run when releases are provided
  updates the version information in the manifest
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:376
•
------------------------------
OutCommand Run when releases are provided
  includes the provided releases in the metadata
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:395
•
------------------------------
OutCommand Run when stemcells are provided
  uploads all of the stemcells
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:458
•
------------------------------
OutCommand Run when stemcells are provided
  updates the version information in the manifest
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:475
•
------------------------------
OutCommand Run when stemcells are provided
  includes the provided stemcells in the metadata
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:484
•
------------------------------
OutCommand Run when a vars store config is provided
  downloads the vars store, uses it, and uploads it
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:511
•
------------------------------
OutCommand Run when a vars store config is provided when the download fails
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:529
•
------------------------------
OutCommand Run when a vars store config is provided when the upload fails
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:542
•
------------------------------
OutCommand Run when the requested operation is a delete
  deletes the deployment
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:565
•
------------------------------
OutCommand Run when the requested operation is a delete when the delete errors
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:581
•
Ran 23 of 23 Specs in 2.290 seconds
SUCCESS! -- 23 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: Storage Suite
============================
Random Seed: 1554224154
Will run 2 of 2 specs

StorageClient NewStorageClient when asking for a GCS client
  returns a GCS client
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/storage/storage_client_test.go:14
•
------------------------------
StorageClient NewStorageClient otherwise
  returns nil
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/storage/storage_client_test.go:32
•
Ran 2 of 2 Specs in 0.002 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: Tools Suite
==========================
Random Seed: 1554224154
Will run 10 of 10 specs

ReadTgzFile
  returns the contents of a file in a gzip tar archive
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/tools/tgz_file_detective_test.go:14
•
------------------------------
ReadTgzFile when the archive does not exist
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/tools/tgz_file_detective_test.go:22
•
------------------------------
ReadTgzFile when the archive is not a valid gzip
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/tools/tgz_file_detective_test.go:30
•
------------------------------
ReadTgzFile when the gzip archive does not contain a valid tar
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/tools/tgz_file_detective_test.go:43
•
------------------------------
ReadTgzFile when file is not in the archive
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/tools/tgz_file_detective_test.go:59
•
------------------------------
GlobUnfurler
  returns all filepaths matching the globs
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/tools/glob_unfurler_test.go:31
•
------------------------------
GlobUnfurler
  returns all filepaths in order
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/tools/glob_unfurler_test.go:47
•
------------------------------
GlobUnfurler when some globs unfurl to the same file
  removes duplicate filepaths
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/tools/glob_unfurler_test.go:65
•
------------------------------
GlobUnfurler when a bad glob is passed
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/tools/glob_unfurler_test.go:82
•
------------------------------
GlobUnfurler when a glob matches no files
  returns an error
  /Users/skutsuza/ghq/src/github.com/cloudfoundry/bosh-deployment-resource/tools/glob_unfurler_test.go:90
•
Ran 10 of 10 Specs in 0.875 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Ginkgo ran 10 suites in 55.831614s
Test Suite Passed
```

</details>