### PR TITLE
Add --fix flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ deployment manifest and then deploy.
 
 * `dry_run`: *Optional.* Shows the deployment diff without running a deploy. Defaults to false.
 
+* `fix`: *Optional.* Recreate an instance with an unresponsive agent instead of erroring. Defaults to false.
+
 * `max_in_flight`: *Optional.* A number of max in flight option.
 
 * `recreate`: *Optional.* Recreate all VMs in deployment. Defaults to false.

--- a/bosh/director.go
+++ b/bosh/director.go
@@ -30,6 +30,7 @@ type DeployParams struct {
 	SkipDrain   []string
 	Cleanup     bool
 	VarsStore   string
+	Fix         bool
 }
 
 type InterpolateParams struct {
@@ -104,6 +105,7 @@ func (d BoshDirector) Deploy(manifestBytes []byte, deployParams DeployParams) er
 		MaxInFlight: convertMaxInFlight(deployParams.MaxInFlight),
 		Recreate:    deployParams.Recreate,
 		SkipDrain:   skipDrains,
+		Fix:         deployParams.Fix,
 		VarFlags: boshcmd.VarFlags{
 			VarKVs:    varKVsFromVars(deployParams.Vars),
 			VarsFiles: boshVarsFiles,

--- a/concourse/out_params.go
+++ b/concourse/out_params.go
@@ -8,6 +8,7 @@ type OutParams struct {
 	Recreate    bool                   `json:"recreate,omitempty"`
 	SkipDrain   []string               `json:"skip_drain,omitempty"`
 	Cleanup     bool                   `json:"cleanup,omitempty"`
+	Fix         bool                   `json:"fix,omitempty"`
 	Releases    []string               `json:"releases,omitempty"`
 	Stemcells   []string               `json:"stemcells,omitempty"`
 	Vars        map[string]interface{} `json:"vars,omitempty"`

--- a/out/out_command.go
+++ b/out/out_command.go
@@ -93,6 +93,7 @@ func (c OutCommand) deploy(outRequest concourse.OutRequest) (OutResponse, error)
 		Recreate:    outRequest.Params.Recreate,
 		SkipDrain:   outRequest.Params.SkipDrain,
 		Cleanup:     outRequest.Params.Cleanup,
+		Fix:         outRequest.Params.Fix,
 		VarFiles:    c.prependResourcesDir(outRequest.Params.VarFiles),
 	}
 

--- a/out/out_command_test.go
+++ b/out/out_command_test.go
@@ -113,6 +113,29 @@ var _ = Describe("OutCommand", func() {
 			}))
 		})
 
+		It("deploys with fix", func() {
+			outRequest.Params.Fix = true
+
+			_, err := outCommand.Run(outRequest)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, actualInterpolateParams := director.InterpolateArgsForCall(0)
+			Expect(actualInterpolateParams.Vars).To(Equal(
+				map[string]interface{}{
+					"foo": "bar",
+				},
+			))
+
+			Expect(director.DeployCallCount()).To(Equal(1))
+			actualManifestYaml, actualDeployParams := director.DeployArgsForCall(0)
+			Expect(actualManifestYaml).To(MatchYAML(manifestYaml))
+			Expect(actualDeployParams).To(Equal(bosh.DeployParams{
+				NoRedact: true,
+				Fix:      true,
+				VarFiles: map[string]string{},
+			}))
+		})
+
 		It("dryrun deploys", func() {
 			outRequest.Params.DryRun = true
 


### PR DESCRIPTION
Useful when you have VMs with unresponsive agent in deployment.

<details><summary>Tests:</summary>

```
Running Suite: Bosh Suite
=========================
Random Seed: 1561219485
Will run 52 of 52 specs

BoshDirector Deploy 
  tells BOSH to deploy the given manifest and parameters
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:47
•
------------------------------
BoshDirector Deploy VarsStore when one is provided 
  is used
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:116
•
------------------------------
BoshDirector Deploy VarsStore when one is not provided 
  is not used
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:129
•
------------------------------
BoshDirector Deploy when deploying fails 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:140
•
------------------------------
BoshDirector Deploy when cleanup is specified 
  runs a cleanup after the deploy
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:150
•
------------------------------
BoshDirector Deploy when dryrun is specified 
  use dry-run flags
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:165
•
------------------------------
BoshDirector Deploy when max in flight is specified 
  use max-in-flight flags
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:181
•
------------------------------
BoshDirector Deploy when skipdrain is specified 
  uses skip-drain flag
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:197
•
------------------------------
BoshDirector Delete 
  tells BOSH to delete the configured deployment
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:216
•
------------------------------
BoshDirector Delete when delete fails 
  returns the error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:231
•
------------------------------
BoshDirector Interpolate 
  tells interpolates a BOSH manifest
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:250
•
------------------------------
BoshDirector Interpolate when interpolating fails 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:302
•
------------------------------
BoshDirector DownloadManifest 
  gets the deployment manifest
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:313
•
------------------------------
BoshDirector DownloadManifest when getting the deployment fails 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:326
•
------------------------------
BoshDirector DownloadManifest when getting the manifest fails 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:336
•
------------------------------
BoshDirector UploadRelease 
  uploads the given release
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:348
•
------------------------------
BoshDirector UploadRelease when uploading the release fails 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:359
•
------------------------------
BoshDirector ExportReleases 
  downloads the given releases
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:412
•
------------------------------
BoshDirector ExportReleases when requesting a release not in the manifest 
  errors before downloading any releases
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:454
•
------------------------------
BoshDirector ExportReleases when there is more than one stemcell in the manifest 
  errors before downloading any releases
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:467
•
------------------------------
BoshDirector ExportReleases when getting the deployment fails 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:480
•
------------------------------
BoshDirector ExportReleases when exporting releases fails 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:491
•
------------------------------
BoshDirector ExportReleases when getting releases fails 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:502
•
------------------------------
BoshDirector ExportReleases when getting stemcells fails from the deployment 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:514
•
------------------------------
BoshDirector ExportReleases when getting stemcells fails from the director 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:525
•
------------------------------
BoshDirector UploadStemcell 
  uploads the given stemcell
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:539
•
------------------------------
BoshDirector UploadStemcell when uploading the stemcell fails 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:550
•
------------------------------
BoshDirector WaitForDeployLock 
  waits for the lock to be released
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:561
•
------------------------------
BoshDirector WaitForDeployLock when there are locks 
  waits for the lock to be released
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:586
•
------------------------------
BoshDirector WaitForDeployLock when checking the lock fails 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/director_test.go:601
•
------------------------------
CLI coordinator StartProxy 
  starts a proxy server and returns the proxy address
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/cli_coordinator_test.go:29
•
------------------------------
CLI coordinator StartProxy when the proxy is already running 
  returns the address for the existing proxy server
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/cli_coordinator_test.go:50
•
------------------------------
CLI coordinator StartProxy when the jumpbox url and the jumpbox ssh key are not set 
  does not start a proxy
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/cli_coordinator_test.go:67
•
------------------------------
CLI coordinator StartProxy when the jumpbox url is set and the ssh key is missing 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/cli_coordinator_test.go:83
•
------------------------------
CLI coordinator StartProxy when the jumpbox ssh key is set and the jumpbox url is missing 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/cli_coordinator_test.go:95
•
------------------------------
DeploymentManifest NewDeploymentManifest 
  returns an error if parsing invalid yaml
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:12
•
------------------------------
DeploymentManifest UseRelease 
  updates the requested release version to match the provided release
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:20
•
------------------------------
DeploymentManifest UseRelease when the release is not found 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:37
•
------------------------------
DeploymentManifest UseRelease when there is no releases section 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:51
•
------------------------------
DeploymentManifest UseStemcell 
  updates the requested stemcell version to match the provided stemcell
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:65
•
------------------------------
DeploymentManifest UseStemcell 
  does not update stemcells when the version is not latest
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:88
•
------------------------------
DeploymentManifest UseStemcell when the stemcell is not found 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:106
•
------------------------------
DeploymentManifest UseStemcell when the stemcell is not found when there is no stemcells section 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:119
•
------------------------------
DeploymentManifest UseStemcell when more than one stemcell matches 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/deployment_manifest_test.go:133
•
------------------------------
Stemcell NewStemcells 
  parses the stemcell tar
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/stemcell_test.go:11
•
------------------------------
Stemcell NewStemcells when the tgz is not a stemcell 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/stemcell_test.go:26
•
------------------------------
Stemcell NewStemcells when the stemcell is malformed 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/stemcell_test.go:35
•
------------------------------
Stemcell NewStemcells when a stemcell glob is bad 
  gives a useful error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/stemcell_test.go:44
•
------------------------------
Release NewRelease 
  parses the release tar
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/release_test.go:11
•
------------------------------
Release NewRelease when the tgz is not a release 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/release_test.go:25
•
------------------------------
Release NewRelease when the release is malformed 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/release_test.go:34
•
------------------------------
Release NewRelease when a release glob is bad 
  gives a useful error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/bosh/release_test.go:43
•
Ran 52 of 52 Specs in 3.015 seconds
SUCCESS! -- 52 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: Check Suite
==========================
Random Seed: 1561219485
Will run 3 of 3 specs

CheckCommand Run When the manifest SHA does not match with the version provided 
  returns the SHA1 of the manifest
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/check/check_command_test.go:43
•
------------------------------
CheckCommand Run When the manifest SHA matches the version provided to the check 
  retuns an empty versions array
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/check/check_command_test.go:70
•
------------------------------
CheckCommand Run When the there is an error downloading the manifest 
  returns the error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/check/check_command_test.go:84
•
Ran 3 of 3 Specs in 0.000 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: Check Suite
==========================
Random Seed: 1561219485
Will run 0 of 0 specs


Ran 0 of 0 Specs in 0.000 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: In Suite
=======================
Random Seed: 1561219485
Will run 0 of 0 specs


Ran 0 of 0 Specs in 0.000 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: Out Suite
========================
Random Seed: 1561219485
Will run 0 of 0 specs


Ran 0 of 0 Specs in 0.000 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: Concourse Suite
==============================
Random Seed: 1561219485
Will run 13 of 13 specs

InRequest NewInRequest when the target is empty 
  It sets a placeholder so newing up the director does not fail validation
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/in_request_test.go:12
•
------------------------------
NewDynamicSource 
  converts the config into a Source
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/source_test.go:14
•
------------------------------
NewDynamicSource when source_file param is passed 
  overrides source with the values in the source_file
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/source_test.go:79
•
------------------------------
NewDynamicSource when source_file param is passed when the source_file cannot be read 
  errors
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/source_test.go:111
•
------------------------------
NewDynamicSource when decoding fails 
  errors
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/source_test.go:121
•
------------------------------
NewDynamicSource when a required parameter is missing 
  returns an error with each missing parameter
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/source_test.go:130
•
------------------------------
NewOutRequest 
  converts the config into an OutRequest
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/out_request_test.go:14
•
------------------------------
NewOutRequest when the dry run flag is true 
  set dryrun to true in OutParams
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/out_request_test.go:90
•
------------------------------
NewOutRequest when source_file param is passed 
  overrides source with the values in the source_file
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/out_request_test.go:123
•
------------------------------
NewOutRequest when decoding fails 
  errors
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/out_request_test.go:188
•
------------------------------
NewOutRequest when delete is specified 
  does not require the manifest parameter
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/out_request_test.go:197
•
------------------------------
NewOutRequest when a required parameter is missing 
  returns an error with each missing parameter
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/out_request_test.go:218
•
------------------------------
Version 
  presents the SHA1 as a string
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/concourse/version_test.go:14
•
Ran 13 of 13 Specs in 0.002 seconds
SUCCESS! -- 13 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: In Suite
=======================
Random Seed: 1561219485
Will run 8 of 8 specs

InCommand Run 
  writes the manifest and target to disk and returns the version as a response
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:55
•
------------------------------
InCommand Run when the manifest download fails 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:81
•
------------------------------
InCommand Run when the manifest download fails if the error is a 404 
  assumes the deployment cannot be found because of an implicit get after a put, where the put was a delete
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:92
•
------------------------------
InCommand Run when downloaded manifest does not match the requested version 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:105
•
------------------------------
InCommand Run when director target does not match the requested version 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:117
•
------------------------------
InCommand Run when requesting compiled_releases 
  downloads each release with the version specified in the manifest
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:149
•
------------------------------
InCommand Run when requesting compiled_releases when exporting releases fails 
  errors
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:167
•
------------------------------
InCommand Run when there are no releases to compile 
  does not export releases
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/in/in_command_test.go:180
•
Ran 8 of 8 Specs in 0.002 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: Out Suite
========================
Random Seed: 1561219485
Will run 24 of 24 specs

OutCommand Run 
  deploys
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:72
•
------------------------------
OutCommand Run 
  deploys with recreate
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:93
•
------------------------------
OutCommand Run 
  deploys with fix
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:116
•
------------------------------
OutCommand Run 
  dryrun deploys
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:139
•
------------------------------
OutCommand Run 
  deploys with max in flight
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:162
•
------------------------------
OutCommand Run 
  deploys with skip drain
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:185
•
------------------------------
OutCommand Run 
  returns the new version
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:208
•
------------------------------
OutCommand Run 
  waits for locks on the deployment
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:224
•
------------------------------
OutCommand Run when varsFiles are provided 
  interpolates the varsFiles into the manifest but does not delpoy with them
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:257
•
------------------------------
OutCommand Run when varsFiles are provided when a varsFile glob is bad 
  gives a useful error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:273
•
------------------------------
OutCommand Run when varFiles are provided 
  prepends the paths with the resources directory and passes them to deploy params
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:284
•
------------------------------
OutCommand Run when opsFiles are provided 
  interpolates the opsfiles into the manifest but does not delpoy with them
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:325
•
------------------------------
OutCommand Run when opsFiles are provided when a opsFile glob is bad 
  gives a useful error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:341
•
------------------------------
OutCommand Run when releases are provided 
  uploads all of the releases
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:382
•
------------------------------
OutCommand Run when releases are provided 
  updates the version information in the manifest
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:399
•
------------------------------
OutCommand Run when releases are provided 
  includes the provided releases in the metadata
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:418
•
------------------------------
OutCommand Run when stemcells are provided 
  uploads all of the stemcells
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:481
•
------------------------------
OutCommand Run when stemcells are provided 
  updates the version information in the manifest
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:498
•
------------------------------
OutCommand Run when stemcells are provided 
  includes the provided stemcells in the metadata
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:507
•
------------------------------
OutCommand Run when a vars store config is provided 
  downloads the vars store, uses it, and uploads it
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:534
•
------------------------------
OutCommand Run when a vars store config is provided when the download fails 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:552
•
------------------------------
OutCommand Run when a vars store config is provided when the upload fails 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:565
•
------------------------------
OutCommand Run when the requested operation is a delete 
  deletes the deployment
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:588
•
------------------------------
OutCommand Run when the requested operation is a delete when the delete errors 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/out/out_command_test.go:604
•
Ran 24 of 24 Specs in 0.023 seconds
SUCCESS! -- 24 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: Storage Suite
============================
Random Seed: 1561219485
Will run 2 of 2 specs

StorageClient NewStorageClient when asking for a GCS client 
  returns a GCS client
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/storage/storage_client_test.go:14
•
------------------------------
StorageClient NewStorageClient otherwise 
  returns nil
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/storage/storage_client_test.go:32
•
Ran 2 of 2 Specs in 0.000 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Running Suite: Tools Suite
==========================
Random Seed: 1561219485
Will run 10 of 10 specs

GlobUnfurler 
  returns all filepaths matching the globs
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/tools/glob_unfurler_test.go:31
•
------------------------------
GlobUnfurler 
  returns all filepaths in order
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/tools/glob_unfurler_test.go:47
•
------------------------------
GlobUnfurler when some globs unfurl to the same file 
  removes duplicate filepaths
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/tools/glob_unfurler_test.go:65
•
------------------------------
GlobUnfurler when a bad glob is passed 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/tools/glob_unfurler_test.go:82
•
------------------------------
GlobUnfurler when a glob matches no files 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/tools/glob_unfurler_test.go:90
•
------------------------------
ReadTgzFile 
  returns the contents of a file in a gzip tar archive
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/tools/tgz_file_detective_test.go:14
•
------------------------------
ReadTgzFile when the archive does not exist 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/tools/tgz_file_detective_test.go:22
•
------------------------------
ReadTgzFile when the archive is not a valid gzip 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/tools/tgz_file_detective_test.go:30
•
------------------------------
ReadTgzFile when the gzip archive does not contain a valid tar 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/tools/tgz_file_detective_test.go:43
•
------------------------------
ReadTgzFile when file is not in the archive 
  returns an error
  /Users/andreikrasnitski/workspace/go/src/github.com/cloudfoundry/bosh-deployment-resource/tools/tgz_file_detective_test.go:59
•
Ran 10 of 10 Specs in 0.003 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Ginkgo ran 10 suites in 8.416188661s
Test Suite Passed
```

</details>