### PR TITLE
Check for YAML unmarshalling error when using source_file param

### DIFF
--- a/concourse/source.go
+++ b/concourse/source.go
@@ -47,7 +47,10 @@ func NewDynamicSource(config []byte, sourcesDir string) (Source, error) {
 		}
 
 		var tempSource Source
-		yaml.Unmarshal(source, &tempSource)
+		err = yaml.Unmarshal(source, &tempSource)
+		if err != nil {
+			return Source{}, fmt.Errorf("Invalid dynamic source config: %s", err)
+		}
 
 		jsonBytes, err := json.Marshal(tempSource)
 		if err != nil {

--- a/concourse/source_test.go
+++ b/concourse/source_test.go
@@ -103,6 +103,29 @@ var _ = Describe("NewDynamicSource", func() {
 			}))
 		})
 
+		Context("when the source_file is invalid yaml", func() {
+			BeforeEach(func() {
+				sourceFile, _ := ioutil.TempFile("", "")
+				sourceFile.Write(properYaml(`
+				deployment=fileDeployments
+			`))
+				sourceFile.Close()
+
+				sourcesDir = filepath.Dir(sourceFile.Name())
+				sourceFileName = filepath.Base(sourceFile.Name())
+			})
+
+			It("errors", func() {
+				config := []byte(fmt.Sprintf(
+					requestJsonTemplate,
+					filepath.Base(sourceFileName),
+				))
+
+				_, err := concourse.NewDynamicSource(config, sourcesDir)
+				Expect(err).To(MatchError(MatchRegexp("Invalid dynamic source config: yaml: unmarshal errors.*")))
+			})
+		})
+
 		Context("when the source_file cannot be read", func() {
 			BeforeEach(func() {
 				sourceFileName = "not-a-real-file"


### PR DESCRIPTION
Previously this error was ignored, and it was difficult to determine what was going wrong without examining the source code in depth.